### PR TITLE
Replace deprecated `K_GUI` with `K_LGUI`

### DIFF
--- a/src/common.nim
+++ b/src/common.nim
@@ -901,7 +901,7 @@ proc valueString*(self: Parameter, value: float): string =
 
 proc ctrl*(): bool =
   when defined(osx):
-    return key(K_GUI)
+    return key(K_LGUI)
   else:
     return key(K_LCTRL)
 


### PR DESCRIPTION
As far as I'm aware, `K_GUI` is deprecated in `nico` and replaced with `K_LGUI` and `K_RGUI`.

Without the change my build fails (`nico` 0.1.0 and `nim` 0.19.4, macOS) with

```
common.nim(904, 16) Error: undeclared identifier: 'K_GUI'
```

With this change it builds normally.